### PR TITLE
Compound keys (flat style)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-/out
-/.idea
+# exact folders
+/out/
+/examples/
+
+# masks
+.idea
+node_modules
 *.log
-/node_modules
 *.sublime-project

--- a/JoiValidationStrategy.js
+++ b/JoiValidationStrategy.js
@@ -1,5 +1,6 @@
 var Joi = require('joi');
 var union = require('lodash.union');
+var flattenAndResetTo = require('./helpers').flattenAndResetTo;
 
 var JoiValidationStrategy = {
   validate: function(joiSchema, data, key) {
@@ -9,20 +10,20 @@ var JoiValidationStrategy = {
       abortEarly: false,
       allowUnknown: true,
     };
-    var errors = this._format(Joi.validate(data, joiSchema, joiOptions));
+    var errors = this.formatErrors(Joi.validate(data, joiSchema, joiOptions));
     if (key === undefined) {
-      union(Object.keys(joiSchema), Object.keys(data)).forEach(function(error) {
-        errors[error] = errors[error] || [];
-      });
-      return errors;
+      return Object.assign(
+        flattenAndResetTo(joiSchema, []),
+        errors
+      );
     } else {
       var result = {};
-      result[key] = errors[key];
+      result[key] = errors[key] || [];
       return result;
     }
   },
 
-  _format: function(joiResult) {
+  formatErrors: function(joiResult) {
     if (joiResult.error !== null) {
       return joiResult.error.details.reduce(function(memo, detail) {
         if (!Array.isArray(memo[detail.path])) {
@@ -35,7 +36,6 @@ var JoiValidationStrategy = {
       return {};
     }
   }
-
 };
 
 module.exports = JoiValidationStrategy;

--- a/JoiValidationStrategy.js
+++ b/JoiValidationStrategy.js
@@ -1,5 +1,4 @@
 var Joi = require('joi');
-var union = require('lodash.union');
 var flattenAndResetTo = require('./helpers').flattenAndResetTo;
 
 var JoiValidationStrategy = {

--- a/ValidationMixin.js
+++ b/ValidationMixin.js
@@ -2,7 +2,9 @@
 
 require('object.assign').shim();
 var result = require('lodash.result');
-var isObject = require('lodash.isObject');
+var merge = require('lodash.merge');
+var isObject = require('lodash.isobject');
+var isArray = require('lodash.isarray');
 var ValidationFactory = require('./ValidationFactory');
 
 var ValidationMixin = {
@@ -32,7 +34,9 @@ var ValidationMixin = {
   validate: function(key) {
     var schema = result(this, 'validatorTypes') || {};
     var data = result(this, 'validatorData') || this.state;
-    var nextErrors = Object.assign({}, this.state.errors, ValidationFactory.validate(schema, data, key));
+    var nextErrors = merge({}, this.state.errors, ValidationFactory.validate(schema, data, key), function(a, b) {
+      return isArray(b) ? b : undefined;
+    });
     this.setState({
       errors: nextErrors
     });

--- a/ValidationMixin.js
+++ b/ValidationMixin.js
@@ -53,32 +53,32 @@ var ValidationMixin = {
    * default is false.
    * @return {function} validation event handler
    */
-  handleUnfocusFor: function(key) {
-    return function handleUnfocus(event) {
-      event.preventDefault();
-      this.validate(key);
-    }.bind(this);
-  },
+  //handleUnfocusFor: function(key) {
+  //  return function handleUnfocus(event) {
+  //    event.preventDefault();
+  //    this.validate(key);
+  //  }.bind(this);
+  //},
 
   /**
    * Convenience method to validate a whole form on submit
    *
    * Usage: <form onSubmit={this.handleSubmit}>...</form>
    */
-  handleSubmit: function(event) {
-    event.preventDefault();
-    this.validate();
-  },
+  //handleSubmit: function(event) {
+  //  event.preventDefault();
+  //  this.validate();
+  //},
 
   /**
    * Convenience method to reset a form to initial state
    *
    * Usage: <button onClick={this.handleReset}>Reset</button>
    */
-  handleReset: function(event) {
-    event.preventDefault();
-    this.setState(this.getInitialState());
-  },
+  //handleReset: function(event) {
+  //  event.preventDefault();
+  //  this.setState(this.getInitialState());
+  //},
 
   /**
    * Get current validation messages for a specified key or entire form.

--- a/ValidationMixin.js
+++ b/ValidationMixin.js
@@ -6,7 +6,6 @@ var isObject = require('lodash.isObject');
 var ValidationFactory = require('./ValidationFactory');
 
 var ValidationMixin = {
-
   /**
    * Check for sane configurations
    */
@@ -44,15 +43,37 @@ var ValidationMixin = {
    * Convenience method to validate a key via an event handler. Useful for
    * onBlur, onClick, onChange, etc...
    *
-   * @param {?String} State key to validate
+   * Usage: <input onBlur={this.handleUnfocusFor('password')} .../>
+   *
+   * @param {?String} key to validate
    * default is false.
    * @return {function} validation event handler
    */
-  handleValidation: function(key) {
-    return function(event) {
+  handleUnfocusFor: function(key) {
+    return function handleUnfocus(event) {
       event.preventDefault();
       this.validate(key);
     }.bind(this);
+  },
+
+  /**
+   * Convenience method to validate a whole form on submit
+   *
+   * Usage: <form onSubmit={this.handleSubmit}>...</form>
+   */
+  handleSubmit: function(event) {
+    event.preventDefault();
+    this.validate();
+  },
+
+  /**
+   * Convenience method to reset a form to initial state
+   *
+   * Usage: <button onClick={this.handleReset}>Reset</button>
+   */
+  handleReset: function(event) {
+    event.preventDefault();
+    this.setState(this.getInitialState());
   },
 
   /**

--- a/ValidationMixin.js
+++ b/ValidationMixin.js
@@ -93,11 +93,7 @@ var ValidationMixin = {
    * @return {Boolean}.
    */
   isValid: function(key) {
-    var errors = this.state.errors;
-    if (key === undefined) {
-      errors = this.validate();
-    }
-    return ValidationFactory.isValid(errors, key);
+    return ValidationFactory.isValid(this.state.errors, key);
   }
 };
 

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,13 @@
+var isPlainObject = require('lodash.isplainobject');
+
+exports.flattenAndResetTo = function flattenAndResetTo(obj, to, path) {
+  path = path || '';
+  return Object.keys(obj).reduce(function(memo, key) {
+    if (isPlainObject(obj[key])) {
+      Object.assign(memo, flattenAndResetTo(obj[key], to, path + key+ '.'));
+    } else {
+      memo[path + key] = to;
+    }
+    return memo;
+  }, {});
+};

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "lodash.flatten": "^2.4.1",
     "lodash.isempty": "^2.4.1",
     "lodash.isobject": "^2.4.1",
+    "lodash.isplainobject": "^3.0.0",
+    "lodash.merge": "^3.0.2",
     "lodash.result": "^3.0.0",
-    "lodash.union": "^3.0.0",
     "object.assign": "^1.1.1"
   }
 }

--- a/spec/HelpersSpec.js
+++ b/spec/HelpersSpec.js
@@ -1,0 +1,98 @@
+var expect = require('chai').expect;
+var flattenAndResetTo = require('../helpers').flattenAndResetTo;
+require('object.assign').shim();
+
+describe('Helpers', function() {
+  describe('flattenAndResetTo()', function() {
+    it('should work with depth 0', function() {
+      var data = {
+        username: "xxx",
+        password: "xxx"
+      };
+
+      expect(flattenAndResetTo(data, undefined)).to.be.eql({
+        'username': undefined,
+        'password': undefined,
+      });
+
+      expect(flattenAndResetTo(data, [])).to.be.eql({
+        'username': [],
+        'password': [],
+      });
+    });
+
+    it('should work with depth 1', function() {
+      var data = {
+        model1: {
+          username: "xxx",
+          password: "xxx"
+        },
+        model2: {
+          username: "xxx",
+          password: "xxx"
+        }
+      };
+
+      expect(flattenAndResetTo(data, undefined)).to.be.eql({
+        'model1.username': undefined,
+        'model1.password': undefined,
+        'model2.username': undefined,
+        'model2.password': undefined
+      });
+
+      expect(flattenAndResetTo(data, [])).to.be.eql({
+        'model1.username': [],
+        'model1.password': [],
+        'model2.username': [],
+        'model2.password': []
+      });
+    });
+
+    it('should work with depth 2', function() {
+      var data = {
+        nsp1: {
+          model1: {
+            username: "xxx",
+            password: "xxx"
+          },
+          model2: {
+            username: "xxx",
+            password: "xxx"
+          }
+        },
+        nsp2: {
+          model1: {
+            username: "xxx",
+            password: "xxx"
+          },
+          model2: {
+            username: "xxx",
+            password: "xxx"
+          }
+        }
+      };
+
+      expect(flattenAndResetTo(data, undefined)).to.be.eql({
+        'nsp1.model1.username': undefined,
+        'nsp1.model1.password': undefined,
+        'nsp1.model2.username': undefined,
+        'nsp1.model2.password': undefined,
+        'nsp2.model1.username': undefined,
+        'nsp2.model1.password': undefined,
+        'nsp2.model2.username': undefined,
+        'nsp2.model2.password': undefined
+      });
+
+      expect(flattenAndResetTo(data, [])).to.be.eql({
+        'nsp1.model1.username': [],
+        'nsp1.model1.password': [],
+        'nsp1.model2.username': [],
+        'nsp1.model2.password': [],
+        'nsp2.model1.username': [],
+        'nsp2.model1.password': [],
+        'nsp2.model2.username': [],
+        'nsp2.model2.password': []
+      });
+    });
+  });
+});

--- a/spec/ValidationMixinSpec.js
+++ b/spec/ValidationMixinSpec.js
@@ -1,0 +1,79 @@
+var expect = require('chai').expect;
+var Joi = require('joi');
+var ValidationMixin = require('../ValidationMixin');
+
+function mockComponent(state, validatorTypes) {
+  state = state || {};
+  validatorTypes = validatorTypes || {};
+  return Object.create(ValidationMixin, {
+    setState: {
+      value: function (state) {
+        this.state = Object.assign(this.state, state);
+      },
+    },
+
+    state: {
+      value: Object.assign(state, {errors: {}}),
+      writable: true,
+    },
+
+    validatorTypes: {
+      value: validatorTypes,
+    }
+  });
+}
+
+describe('ValidationMixin', function() {
+  describe('validate()', function() {
+    it('should keep state errors for flat keys', function() {
+      var component = mockComponent({
+        username: undefined,
+        password: undefined,
+      }, {
+        username: Joi.string().required(),
+        password: Joi.string().required(),
+      });
+
+      component.validate();
+      expect(Object.keys(component.state.errors)).to.eql(['username', 'password']);
+      expect(component.state.errors.username.length).to.eql(1);
+      expect(component.state.errors.password.length).to.eql(1);
+
+      component.state.username = 'foo';
+
+      component.validate();
+      expect(Object.keys(component.state.errors)).to.eql(['username', 'password']);
+      expect(component.state.errors.username.length).to.eql(0);
+      expect(component.state.errors.password.length).to.eql(1);
+
+      component.state.password = 'bar';
+
+      component.validate();
+      expect(Object.keys(component.state.errors)).to.eql(['username', 'password']);
+      expect(component.state.errors.username.length).to.eql(0);
+      expect(component.state.errors.password.length).to.eql(0);
+    });
+
+    it('should keep state errors for compound keys', function() {
+      var component = mockComponent({model: {
+        username: 'foo',
+        password: undefined,
+      }}, {model: {
+        username: Joi.string().required(),
+        password: Joi.string().required(),
+      }});
+
+      component.validate();
+      expect(Object.keys(component.state.errors)).to.eql(['model.username', 'model.password']);
+      expect(component.state.errors['model.username'].length).to.eql(0);
+      expect(component.state.errors['model.password'].length).to.eql(1);
+
+      component.state.model.password = 'bar';
+
+      component.validate();
+      expect(Object.keys(component.state.errors)).to.eql(['model.username', 'model.password']);
+      expect(component.state.errors['model.username'].length).to.eql(0);
+      expect(component.state.errors['model.password'].length).to.eql(0);
+    });
+  });
+});


### PR DESCRIPTION
With compound keys like `model.username` resulting validation messages 
may be represented in two styles:

```javascript
{
  model: {username: []} // nested style (closed PR #12)
}

{
  model.username: [] // flat style (current PR #13)
}
```

Previous attempt at (https://github.com/jurassix/react-validation-mixin/pull/12) is working but implementation is really complex. All lens libraries I analized are borked. To not create another one, I decided to abandon previous approach and implemented new one where errors object is kept flat. It turned out to be much cleaner.

Now code & tests are ready for review :)
