### PR TITLE
use he.decode to display original string entity

### DIFF
--- a/ValidationFactory.js
+++ b/ValidationFactory.js
@@ -2,6 +2,7 @@ require('object.assign').shim();
 var isEmpty = require('lodash.isempty');
 var flatten = require('lodash.flatten');
 var ValidationStrategy = require('./JoiValidationStrategy');
+var he = require('he');
 
 var ValidationFactory = Object.assign({
   getValidationMessages: function(errors, key) {
@@ -14,7 +15,7 @@ var ValidationFactory = Object.assign({
           return errors[error] || [];
         }));
       } else {
-        return errors[key] || [];
+        return errors[key]? errors[key].map(he.decode): [];
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lodash.isobject": "^3.0.0",
     "lodash.result": "^3.0.0",
     "lodash.union": "^3.0.0",
-    "object.assign": "^1.1.1"
+    "object.assign": "^1.1.1",
+    "he": "^0.5.0"
   }
 }

--- a/spec/ValidationFactorySpec.js
+++ b/spec/ValidationFactorySpec.js
@@ -120,6 +120,15 @@ describe('Validation Factory', function() {
         expect(result.length).to.equal(0);
       });
 
+      it('should be decode for HTML entity encoder', function() {
+        var label = '使用者名稱';
+        var schema = {username: Joi.string().required().label(label)};
+        var data = {username: ''};
+        var errors = ValidationFactory.validate(schema, data);
+        var result = ValidationFactory.getValidationMessages(errors, 'username');
+        expect(result[0]).to.equal(label+' is not allowed to be empty');
+      });
+
       it('should be filled for invalid input', function() {
         var schema = {username: Joi.string().required()};
         var data = {};


### PR DESCRIPTION
based on <https://github.com/hapijs/joi/issues/635>. The error message should be decode from ```getValidationMessages``` function. 
* add dependency ```he```