### PR TITLE
it should be able to set other joiOptions

### DIFF
--- a/JoiValidationStrategy.js
+++ b/JoiValidationStrategy.js
@@ -1,14 +1,15 @@
 var Joi = require('joi');
 var union = require('lodash.union');
+require('object.assign').shim();
 
 var JoiValidationStrategy = {
-  validate: function(joiSchema, data, key) {
+  validate: function(joiSchema, data, key, _joiOptions) {
     joiSchema = joiSchema || {};
     data = data || {};
-    var joiOptions = {
+    var joiOptions = Object.assign({
       abortEarly: false,
       allowUnknown: true,
-    };
+    }, _joiOptions);
     var errors = this._format(Joi.validate(data, joiSchema, joiOptions));
     if (key === undefined) {
       union(Object.keys(joiSchema), Object.keys(data)).forEach(function(error) {

--- a/ValidationMixin.js
+++ b/ValidationMixin.js
@@ -32,7 +32,12 @@ var ValidationMixin = {
     }
     var schema = result(this, 'validatorTypes') || {};
     var data = result(this, 'getValidatorData') || this.state;
-    var validationErrors = Object.assign({}, this.state.errors, ValidationFactory.validate(schema, data, key));
+    var joiOptions = null;
+    if (this.joiOptions !== undefined && isObject(this.joiOptions)) {
+      joiOptions = this.joiOptions;
+    }
+    console.log(this.joiOptions);
+    var validationErrors = Object.assign({}, this.state.errors, ValidationFactory.validate(schema, data, key, joiOptions));
     this.setState({
       errors: validationErrors
     }, this._invokeCallback.bind(this, key, callback));
@@ -99,7 +104,6 @@ var ValidationMixin = {
       callback(new Error('Validation errors exist'), this.state.errors);
     }
   }
-
 };
 
 module.exports = ValidationMixin;

--- a/ValidationMixin.js
+++ b/ValidationMixin.js
@@ -36,7 +36,6 @@ var ValidationMixin = {
     if (this.joiOptions !== undefined && isObject(this.joiOptions)) {
       joiOptions = this.joiOptions;
     }
-    console.log(this.joiOptions);
     var validationErrors = Object.assign({}, this.state.errors, ValidationFactory.validate(schema, data, key, joiOptions));
     this.setState({
       errors: validationErrors

--- a/spec/ValidationFactorySpec.js
+++ b/spec/ValidationFactorySpec.js
@@ -193,5 +193,20 @@ describe('Validation Factory', function() {
         expect(result).to.be.false;
       });
     });
+    describe('setJoiOptions', function() {
+      it('should setJoiOptions', function() {
+        var schema = {username: Joi.string().required()};
+        var data = {username: ''};
+        var customRequiredString = 'is not allowed to be blank';
+        var joiOptions = {
+          language:{
+            any: {empty: customRequiredString}
+          }
+        };
+
+        var result = ValidationFactory.validate(schema, data, 'username', joiOptions);
+        expect(result).to.eql({username: ['username '+customRequiredString]});
+      });
+    });
   });
 });


### PR DESCRIPTION
@jurassix , I need to set options of Joi, especially on the ```language``` option.

 I do notice that you have set the ```joiOptions``` <https://github.com/jurassix/react-validation-mixin/blob/master/JoiValidationStrategy.js#L8>, but it have no way to set other options on it. so I added  joiOptions to set it. I don't know if it is follow your coding guideline, hope you can take some time to review it. Thank you very much.