### PR TITLE
Fix for #38

### DIFF
--- a/src/components/validationMixin.js
+++ b/src/components/validationMixin.js
@@ -64,7 +64,7 @@ export default function(strategy) {
         invariant(defined(schema), 'A schema was not provided to the Validator. Implement "validatorTypes" to return a validation schema.');
 
         validator.validate(data, schema, _key, validationErrors => {
-          const errors = {...this.state.errors, ...validationErrors};
+          const errors = {...validationErrors};
           this.setState({ errors }, this._invokeCallback.bind(this, _key, _callback));
         });
       }


### PR DESCRIPTION
This is a fix for the Issue #38 (*error messages doesn't clear when validating array of items*)

Observation: The result looks as follows:

```
data: Array[0]
data.0: Array[1]
data.1: Array[1]
data.2: Array[1]
```

If I make the array field valid, then the `data.*` are still set in the `errors` object. Because of this, this fix does not extends the stored `errors` object anymore. Instead, it `rewrites` them and Reacts `setState()` should still just update the diff.

Like this, errors for nested objects should be `removed`as well.