### PR TITLE
Added posibility to clear validation for the specified key

### DIFF
--- a/src/components/validationMixin.js
+++ b/src/components/validationMixin.js
@@ -70,11 +70,23 @@ export default function(strategy) {
         });
       }
 
-      /* Clear all previous validations
+      /* Clear previous validations for a specified key or entire form
        *
        * @return {void}
        */
-      clearValidations(callback) {
+      clearValidations(/* [key], callback */) {
+        const fallback = arguments.length <= 1 && typeof arguments[0] === 'function' ? arguments[0] : undefined;
+        const key = arguments.length <= 1 && typeof arguments[0] === 'function' ? undefined : arguments[0];
+        const callback = arguments.length <= 2 && typeof arguments[1] === 'function' ? arguments[1] : fallback;          
+        
+        if (key){
+          return this.setState((prevState, currProps) => {
+            const errors = prevState.errors;
+			delete errors[key];
+            return {errors: errors};
+          }, callback);
+        }  
+          
         return this.setState({
           errors: {},
         }, callback);


### PR DESCRIPTION
In some my projects I needed to clear validation just for the field that is being changed at the moment, but not the entire form. I decided to modify _clearValidations_ method to add optional _key_ parameter for this reason. Hope you'll like this idea.
