### PR TITLE
Adds a filter to test the existence of errors after validating

### DIFF
--- a/src/components/validationMixin.js
+++ b/src/components/validationMixin.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import invariant from 'invariant';
 import result from 'lodash.result';
+import values from 'lodash.values';
 import factory from '../validationFactory';
 import getDisplayName from 'react-display-name';
 import { defined } from '../utils';
@@ -65,7 +66,10 @@ export default function validationMixin(strategy) {
           key,
           prevErrors: this.state.errors,
         };
-        validator.validate(data, schema, options, nextErrors => {
+        validator.validate(data, schema, options, existentErrors => {
+          const errors = values(existentErrors).filter(error => error && error.length > 0);
+          const nextErrors = errors.length === 0 ? {} : existentErrors;
+
           this.setState({ errors: { ...nextErrors } }, this._invokeCallback.bind(this, key, callback));
         });
       }


### PR DESCRIPTION
When using validate with a field as param, as in: `this.props.validate('email')` in a form with multiple fields, the errors state may have the following format:

```js
errors: {
  email: Array(1),
  name: Array(1)
  ...etc
}
```

if I do not have any errors it gets the following format:
```js
errors: {
  email: Array(0),
  name: Array(0)
  ...etc
}
```

If I do not call `this.props.validate()` (without passing the field) the `isValid` method returns false, even though there are no errors. Im using `react-validatorjs-strategy` as a strategy.

So, I thought of doing this workaround and testing whether there are errors or not, and passing the empty errors object if there arent. I'm using loadash.values and filter to prevent adding new more libs. 

What do you think? Am I missing anything?

Thanks in advance!


